### PR TITLE
Fix default geometry for scaled screens

### DIFF
--- a/flokk_src/linux/my_application.cc
+++ b/flokk_src/linux/my_application.cc
@@ -16,8 +16,10 @@ static void my_application_activate(GApplication* application) {
   GtkWindow* window =
       GTK_WINDOW(gtk_application_window_new(GTK_APPLICATION(application)));
   gtk_widget_show(GTK_WIDGET(window));
-  gtk_widget_set_size_request(GTK_WIDGET(window), kFlutterWindowWidth,
-                              kFlutterWindowHeight);
+  GdkWindow *gdk_window = gtk_widget_get_window(GTK_WIDGET(window));
+  gint scale_factor = gdk_window_get_scale_factor(gdk_window);
+  gtk_widget_set_size_request(GTK_WIDGET(window), kFlutterWindowWidth/scale_factor,
+                              kFlutterWindowHeight/scale_factor);
   gtk_window_set_title(window, kFlutterWindowTitle);
 
   g_autoptr(FlDartProject) project = fl_dart_project_new();
@@ -29,8 +31,7 @@ static void my_application_activate(GApplication* application) {
   fl_register_plugins(FL_PLUGIN_REGISTRY(view));
 
   gtk_widget_grab_focus(GTK_WIDGET(view));
-}
-
+} 
 static void my_application_class_init(MyApplicationClass* klass) {
   G_APPLICATION_CLASS(klass)->activate = my_application_activate;
 }

--- a/flokk_src/linux/my_application.h
+++ b/flokk_src/linux/my_application.h
@@ -2,7 +2,7 @@
 #define FLUTTER_MY_APPLICATION_H_
 
 #include <gtk/gtk.h>
-
+#include <gdk/gdk.h>
 G_DECLARE_FINAL_TYPE(MyApplication, my_application, MY, APPLICATION,
                      GtkApplication)
 


### PR DESCRIPTION
There is an issue when the application starts up on a scaled (HiDpi) monitor. gtk_widget_set_size_request sets the minimum size for the window. It currently uses 1376x768. On  a screen with scale factor of 2, this 2752x1376. I have a 2160x1440 display. Therefore the width is too large to fit on the screen. I updated the code to first get the scale factor and divide the preferred width and height by the scale factor. This now shows up correctly on my display.