### PR TITLE
Fix opening Github URL

### DIFF
--- a/flokk_src/lib/_internal/url_launcher/url_launcher.dart
+++ b/flokk_src/lib/_internal/url_launcher/url_launcher.dart
@@ -35,7 +35,7 @@ class UrlLauncher {
 
   static void openGoogleMaps(String value) => open("https://www.google.com/maps/search/${Uri.encodeFull(value)}/");
 
-  static void openGitUser(String value) => open("https://github.com/$value/");
+  static void openGitUser(String value) => open("https://$value/");
 
   static void openTwitterUser(String value) => open("https://twitter.com/${value.replaceAll("@", "")}/");
 }


### PR DESCRIPTION
The generated URL for Github profile was wrong because `github.com` was repeated.